### PR TITLE
Compatible with Hypothesis 6.x, add classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later"
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Environment :: Console",
+    "Framework :: Hypothesis",
     "Programming Language :: Python :: 3.7",
     "Topic :: Software Development :: Testing"
 ]
@@ -15,7 +16,7 @@ repository = "https://github.com/machielg/sparkle-hypothesis/"
 
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
-hypothesis = "^5.35.3"
+hypothesis = ">=5.35.3"
 sparkle-test = "^1.1.0"
 sparkle-session = "^1.2.1"
 


### PR DESCRIPTION
Restricting the version of Hypothesis to `5.35.3` or `5.35.4` is *wildly* restrictive, and I don't think what you actually intended - the `^` version restriction is much harsher than most people think.  As well as switching to the more sensible `>=` so that your users can benefit from the many new features and performance improvements since then, I've added the `Hypothesis` classifier so that more Hypothesis users can find your package.